### PR TITLE
Add `--skip` flag for allowing non-digest-named files

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,12 +12,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.17
       - name: Checkout
         uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.44.0
+          version: latest
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -14,14 +14,38 @@ Run `staticassetlint` as part of a build to prevent accidentally polluting
 cache-forever never-revalidate asset delivery with files that are not
 correctly named.
 
-    staticassetlint /workspace/foo_public /workplace/bar_public ...
+```shell
+staticassetlint /workspace/foo_public /workplace/bar_public ...
+```
+
+### Skipping files
+
+Some asset pipelines produce files that are named based on a hash of an
+intermediate state that is impractical or impossible to reconstruct from the
+files on disk.
+
+You can allowlist patterns that you know are safe for use with write-once
+distribution using the `--skip` flag.
+
+Each `--skip` regular expression is anchored before compilation, meaning that
+it must match the entire name of the file. (`--skip '-bar\.js'` will match
+a file named `-bar.js` but not a file named `foo-bar.js`.)
+
+Example:
+
+```shell
+staticassetlint \
+    --skip '.*-[0-9a-f]{32}.(?:js|map|css)' \
+    --skip 'chunk.\d{3}\.[0-9a-f]{20}\.(?:js|js\.LICENSE\.txt|map)' \
+    /workspace/web_root/assets
+```
 
 ## Contributing
 
 Contributions considered, but be aware that this is mostly just something we
 needed. It's public because there's no reason anyone else should have to waste
 an afternoon (or more) building something similar, and we think the approach
-is good enough that others might benefit from adopting.
+is useful enough that others might benefit from adopting it.
 
 This project is licensed under the [Apache License, Version 2.0](LICENSE).
 

--- a/digestnamed/patterns.go
+++ b/digestnamed/patterns.go
@@ -1,0 +1,95 @@
+// Copyright 2022 RetailNext, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digestnamed
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type ignorePatterns []*regexp.Regexp
+
+func (i ignorePatterns) MatchString(s string) bool {
+	for _, r := range i {
+		if r.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func makeIgnorePatterns(patterns []string) (ignorePatterns, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	result := make([]*regexp.Regexp, 0, len(patterns))
+	for _, expr := range patterns {
+		r, err := regexp.Compile("^" + expr + "$")
+		if err != nil {
+			return nil, err
+		}
+		err = validateIgnoreRegexp(r)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func makeHexRegexp(lengths ...int) *regexp.Regexp {
+	sortedLengths := append([]int(nil), lengths...)
+	sort.Sort(sort.Reverse(sort.IntSlice(sortedLengths)))
+
+	var acc strings.Builder
+	for i, digits := range sortedLengths {
+		if i > 0 {
+			if _, err := acc.WriteRune('|'); err != nil {
+				panic(err)
+			}
+		}
+		if _, err := fmt.Fprintf(&acc, "[0-9a-f]{%d}|[0-9A-F]{%d}", digits, digits); err != nil {
+			panic(err)
+		}
+	}
+	return regexp.MustCompile(acc.String())
+}
+
+var hexPattern = makeHexRegexp(64, 40, 32)
+
+var namesIgnorePatternsMustNotMatch = []string{
+	"",
+	"''",
+	".",
+	"..",
+	".DS_Store",
+	".htaccess",
+	"\"\"",
+	"favicon.ico",
+	"index.html",
+	"robots.txt",
+}
+
+func validateIgnoreRegexp(r *regexp.Regexp) error {
+	for _, s := range namesIgnorePatternsMustNotMatch {
+		if r.MatchString(s) {
+			return fmt.Errorf("pattern %q is invalid because it matched %q", r.String(), s)
+		}
+	}
+	return nil
+}

--- a/digestnamed/patterns_test.go
+++ b/digestnamed/patterns_test.go
@@ -1,0 +1,103 @@
+// Copyright 2022 RetailNext, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digestnamed
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestExtractHexDigest(t *testing.T) {
+	cases := map[string]string{
+		"vendor-c2293867abd250a96bb64cc0c78ed603.css":                         "c2293867abd250a96bb64cc0c78ed603",
+		"vendor-C2293867ABD250A96BB64CC0C78ED603.css":                         "c2293867abd250a96bb64cc0c78ed603",
+		"vendor-415ab40ae9b7cc4e66d6769cb2c08106e8293b48.css":                 "415ab40ae9b7cc4e66d6769cb2c08106e8293b48",
+		"9e58e1c69c2c77d6be328dd795d7154f25e5ea3718c2c0d0f6ea6017cfb8b3dc.gz": "9e58e1c69c2c77d6be328dd795d7154f25e5ea3718c2c0d0f6ea6017cfb8b3dc",
+	}
+	for input, expected := range cases {
+		result := extractHexDigest(input)
+		if result != expected {
+			t.Fatalf("input:%q expected:%q result:%q", input, expected, result)
+		}
+	}
+}
+
+type ignorePatternsTestCase struct {
+	patterns            []string
+	expectCreateFailure bool
+	shouldMatch         []string
+	shouldNotMatch      []string
+}
+
+func (c ignorePatternsTestCase) check() error {
+	compiled, err := makeIgnorePatterns(c.patterns)
+	if c.expectCreateFailure {
+		if err == nil {
+			return fmt.Errorf("expected creating patterns=%+v to fail, got nil error", c.patterns)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("creating patterns=%+v failed: %w", c.patterns, err)
+	}
+	for _, s := range c.shouldMatch {
+		if !compiled.MatchString(s) {
+			return fmt.Errorf("expected patterns=%+v to match %q", c.patterns, s)
+		}
+	}
+	for _, s := range c.shouldNotMatch {
+		if compiled.MatchString(s) {
+			return fmt.Errorf("expected patterns=%+v to match %q but it did not", c.patterns, s)
+		}
+	}
+	return nil
+}
+
+func TestIgnorePatterns(t *testing.T) {
+	cases := []ignorePatternsTestCase{
+		{
+			patterns: []string{
+				".*",
+			},
+			expectCreateFailure: true,
+		},
+		{
+			patterns: []string{
+				".+",
+			},
+			expectCreateFailure: true,
+		},
+		{
+			patterns:       nil,
+			shouldNotMatch: []string{"", "."},
+		},
+		{
+			patterns: []string{
+				"[0-9a-f]{8}.gif",
+			},
+			shouldMatch: []string{
+				"aaaaaaaa.gif",
+			},
+			shouldNotMatch: []string{
+				".DS_Store",
+			},
+		},
+	}
+	for _, tc := range cases {
+		if err := tc.check(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,8 @@ module github.com/retailnext/staticassetlint
 go 1.17
 
 require (
-	github.com/alecthomas/kong v0.5.0
+	github.com/alecthomas/kong v0.5.1-0.20220407204308-7c6ff10d3388
 	go.uber.org/multierr v1.8.0
 )
 
-require (
-	github.com/pkg/errors v0.9.1 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
-)
+require go.uber.org/atomic v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,10 @@
-github.com/alecthomas/kong v0.5.0 h1:u8Kdw+eeml93qtMZ04iei0CFYve/WPcA5IFh+9wSskE=
-github.com/alecthomas/kong v0.5.0/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
+github.com/alecthomas/kong v0.5.1-0.20220407204308-7c6ff10d3388 h1:6XoG4kvyii8ISXR93ju0VrRIJhANM2ZdBzMZE60gXj0=
+github.com/alecthomas/kong v0.5.1-0.20220407204308-7c6ff10d3388/go.mod h1:GaAkr/DV/nSKftP7snQLewFh9pZqrm+OEn3HqkvWU7c=
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142 h1:8Uy0oSf5co/NZXje7U1z8Mpep++QJOldL2hs/sBQf48=
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
*   Add `--skip` flag

    Some asset pipelines produce files that are named based on a hash of an
    intermediate state that is impractical or impossible to reconstruct from
    the files on disk.

*   Upgrade kong to fix parsing flag values that look like flags.

    https://github.com/alecthomas/kong/issues/290

Signed-off-by: Erik Swanson <erik@retailnext.net>